### PR TITLE
chore: fix background of yamlline ui element

### DIFF
--- a/lua/keytrail/highlights.lua
+++ b/lua/keytrail/highlights.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local config = require('keytrail.config')
+local config = require("keytrail.config")
 
 ---Set up all highlight groups
 function M.setup()
@@ -26,10 +26,10 @@ function M.setup()
     for i, color in ipairs(config.get().colors) do
         vim.api.nvim_set_hl(0, "YAMLPathline" .. i, {
             fg = color,
+            bg = "NONE",
             bold = false,
         })
     end
 end
 
 return M
-


### PR DESCRIPTION
Hello 👋 

I small PR to change the background color of the yamlline ui element. In my case it was showing like this:

![Screenshot 2025-06-22 at 13 12 55](https://github.com/user-attachments/assets/dcd70f67-1b47-41b6-a3ae-5795ca9ba834)

With the change it shows up like this: 

![Screenshot 2025-06-22 at 13 14 10](https://github.com/user-attachments/assets/4874894b-87d7-4c08-b5b3-1f3967efaad6)
