### PR TITLE
Implement KeyTrailYank

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Neovim plugin in pure lua that shows the current path in YAML and JSON files, 
 - Shows the current path in YAML and JSON files
 - Hover popup with the current path
 - Jump to any path in the document using Telescope
+- Yank (copy) the current path to clipboard
 - Support for both YAML and JSON file types
 - Configurable delimiter and hover delay
 - Customizable key mapping
@@ -85,6 +86,8 @@ require("keytrail").setup({
     hover_delay = 100,
     -- The key mapping to use for jumping to a path
     key_mapping = "jq",
+    -- The key mapping to use for yanking the current path
+    yank_key_mapping = "jy",
     -- The file types to enable KeyTrail for
     filetypes = {
         yaml = true,
@@ -98,6 +101,7 @@ KeyTrail provides the following commands:
 
 - `:KeyTrail <path>` - Jump to the specified path
 - `:KeyTrailJump` - Open Telescope to select and jump to a path
+- `:KeyTrailYank` - Yank (copy) the current path to the clipboard
 
-By default, KeyTrail maps `<leader>jq` to `:KeyTrailJump` in normal mode.
+By default, KeyTrail maps `<leader>jq` to `:KeyTrailJump` and `<leader>jy` to `:KeyTrailYank` in normal mode.
 

--- a/lua/keytrail/config.lua
+++ b/lua/keytrail/config.lua
@@ -31,7 +31,8 @@ local default_config = {
         yaml = true,
         json = true
     },
-    key_mapping = "jq" -- Key mapping for jump window (will be prefixed with <leader>)
+    key_mapping = "jq",       -- Key mapping for jump window (will be prefixed with <leader>)
+    yank_key_mapping = "jy"   -- Key mapping for yank command (will be prefixed with <leader>)
 }
 
 ---@type KeyTrailConfig

--- a/lua/keytrail/init.lua
+++ b/lua/keytrail/init.lua
@@ -244,7 +244,7 @@ function M.ensure_setup(opts)
     highlights.setup()
     setup()
 
-    -- Set up default key mapping
+    -- Set up default key mapping for jump
     vim.keymap.set('n', '<leader>' .. config.get().key_mapping, function()
         local ft = vim.bo.filetype
         if not config.get().filetypes[ft] then
@@ -253,6 +253,11 @@ function M.ensure_setup(opts)
         end
         jump.jumpwindow()
     end, { desc = 'KeyTrail: Jump to path', silent = true })
+
+    -- Set up default key mapping for yank
+    vim.keymap.set('n', '<leader>' .. config.get().yank_key_mapping, function()
+        M.handle_yank_command()
+    end, { desc = 'KeyTrail: Yank current path', silent = true })
 end
 
 -- Command handlers
@@ -285,6 +290,24 @@ function M.handle_jump_command()
     if not jump.jumpwindow() then
         vim.notify("KeyTrail: Could not jump to specified path", vim.log.levels.ERROR)
     end
+end
+
+function M.handle_yank_command()
+    ensure_modules()
+    local ft = vim.bo.filetype
+    if not config.get().filetypes[ft] then
+        vim.notify("KeyTrail: Current filetype not supported", vim.log.levels.ERROR)
+        return
+    end
+
+    local path = get_path()
+    if path == "" then
+        vim.notify("KeyTrail: No path found at cursor position", vim.log.levels.WARN)
+        return
+    end
+
+    vim.fn.setreg('+', path)
+    vim.notify("KeyTrail: Yanked path: " .. path, vim.log.levels.INFO)
 end
 
 -- Legacy setup function for manual configuration

--- a/plugin/keytrail.lua
+++ b/plugin/keytrail.lua
@@ -17,6 +17,12 @@ local function setup_lazy()
         require('keytrail').handle_jump_command()
     end, {})
 
+    -- Create the KeyTrailYank command
+    vim.api.nvim_create_user_command('KeyTrailYank', function()
+        require('keytrail').ensure_setup()
+        require('keytrail').handle_yank_command()
+    end, {})
+
     -- Set up filetype autocommand for lazy initialization
     vim.api.nvim_create_autocmd("FileType", {
         pattern = { "yaml", "json" },


### PR DESCRIPTION
This MR implements a `KeyTrailYank` user command and binds it to `<leader>jy`.

As with `KeyTrailJump`/`<leader>jq`, the default key sequence can be overridden via `setup`.

Closes #9 